### PR TITLE
Manage course students

### DIFF
--- a/src/main/java/it/ettore/controller/professor/ProfessorCourseController.java
+++ b/src/main/java/it/ettore/controller/professor/ProfessorCourseController.java
@@ -64,4 +64,105 @@ public class ProfessorCourseController {
 
         return "professor/courses/details";
     }
+
+    @GetMapping(value = "/professor/courses/{id}/manage")
+    public String courseManagePage(@PathVariable @NotNull long id, Model model, HttpServletRequest request) {
+        User professor = Utils.loggedUser(request);
+
+        Optional<Course> maybeCourse = repoCourse.findById(id);
+        // On wrong ID, redirect to courses list
+        if (maybeCourse.isEmpty()) {
+            return "redirect:/professor/courses";
+        }
+        Course course = maybeCourse.get();
+
+        // Add attributes
+        model.addAllAttributes(
+                Map.of(
+                        "user", professor,
+                        "breadcrumbs", List.of(
+                                new Breadcrumb("Courses", "/professor/courses"),
+                                new Breadcrumb(course.getName(), String.format("/professor/courses/%d", course.getId())),
+                                new Breadcrumb("Manage", String.format("/professor/courses/%d/manage", course.getId()))
+                        ),
+                        "course", course,
+                        "studentsRequesting", course.getStudentsRequesting(),
+                        "studentsJoined", course.getStudentsJoined()
+                )
+        );
+
+        return "professor/courses/manage";
+    }
+
+    @GetMapping(value = "/professor/courses/{id}/accept/{studentId}")
+    public String courseAcceptStudent(@PathVariable @NotNull long id, @PathVariable @NotNull long studentId, Model model, HttpServletRequest request) {
+        User professor = Utils.loggedUser(request);
+
+        Optional<Course> maybeCourse = repoCourse.findById(id);
+        // On wrong ID, redirect to courses list
+        if (maybeCourse.isEmpty()) {
+            return "redirect:/professor/courses";
+        }
+        Course course = maybeCourse.get();
+
+        Optional<User> maybeStudent = repoUser.findById(studentId);
+        // On wrong ID, redirect to course manage page as if nothing had happened
+        if (maybeStudent.isEmpty()) {
+            return String.format("redirect:/professor/courses/%d/manage", id);
+        }
+        User student = maybeStudent.get();
+
+        course.acceptStudent(student);
+        repoCourse.save(course);
+
+        return String.format("redirect:/professor/courses/%d/manage", id);
+    }
+
+    @GetMapping(value = "/professor/courses/{id}/reject/{studentId}")
+    public String courseRejectStudent(@PathVariable @NotNull long id, @PathVariable @NotNull long studentId, Model model, HttpServletRequest request) {
+        User professor = Utils.loggedUser(request);
+
+        Optional<Course> maybeCourse = repoCourse.findById(id);
+        // On wrong ID, redirect to courses list
+        if (maybeCourse.isEmpty()) {
+            return "redirect:/professor/courses";
+        }
+        Course course = maybeCourse.get();
+
+        Optional<User> maybeStudent = repoUser.findById(studentId);
+        // On wrong ID, redirect to course manage page as if nothing had happened
+        if (maybeStudent.isEmpty()) {
+            return String.format("redirect:/professor/courses/%d/manage", id);
+        }
+        User student = maybeStudent.get();
+
+        course.rejectStudent(student);
+        repoCourse.save(course);
+
+        return String.format("redirect:/professor/courses/%d/manage", id);
+    }
+
+    @GetMapping(value = "/professor/courses/{id}/remove/{studentId}")
+    public String courseRemoveStudent(@PathVariable @NotNull long id, @PathVariable @NotNull long studentId, Model model, HttpServletRequest request) {
+        User professor = Utils.loggedUser(request);
+
+        Optional<Course> maybeCourse = repoCourse.findById(id);
+        // On wrong ID, redirect to courses list
+        if (maybeCourse.isEmpty()) {
+            return "redirect:/professor/courses";
+        }
+        Course course = maybeCourse.get();
+
+        Optional<User> maybeStudent = repoUser.findById(studentId);
+        // On wrong ID, redirect to course manage page as if nothing had happened
+        if (maybeStudent.isEmpty()) {
+            return String.format("redirect:/professor/courses/%d/manage", id);
+        }
+        User student = maybeStudent.get();
+
+        course.removeStudent(student);
+        repoCourse.save(course);
+
+        return String.format("redirect:/professor/courses/%d/manage", id);
+    }
 }

--- a/src/main/java/it/ettore/model/Course.java
+++ b/src/main/java/it/ettore/model/Course.java
@@ -5,6 +5,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -33,6 +35,14 @@ public class Course {
     @ManyToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "professor_id", nullable = false)
     private User professor;
+
+    @ManyToMany(cascade = CascadeType.ALL)
+    @JoinTable(name = "course_request", joinColumns = @JoinColumn(name = "course_id"), inverseJoinColumns = @JoinColumn(name = "user_id"))
+    private List<User> studentsRequesting;
+
+    @ManyToMany(cascade = CascadeType.ALL)
+    @JoinTable(name = "course_join", joinColumns = @JoinColumn(name = "course_id"), inverseJoinColumns = @JoinColumn(name = "user_id"))
+    private List<User> studentsJoined;
 
     public Course(String name, String description, int startingYear, Category category, User professor) {
         this.name = name;
@@ -70,5 +80,56 @@ public class Course {
     @Override
     public String toString() {
         return String.format("Course{id=%d,name=%s}", id, name);
+    }
+
+    public void requestJoin(User student) {
+        if (studentsJoined != null && studentsJoined.contains(student)) {
+            throw new IllegalStateException("This student has already joined, no need to request");
+        }
+
+        if (studentsRequesting == null) {
+            studentsRequesting = new ArrayList<>();
+        } else if (studentsRequesting.contains(student)) {
+            throw new IllegalStateException("This student has already requested to join");
+        }
+
+        studentsRequesting.add(student);
+    }
+
+    public void acceptStudent(User student) {
+        if (studentsRequesting == null || !studentsRequesting.contains(student)) {
+            throw new IllegalStateException("This student has no pending request to join this course");
+        }
+
+        if (studentsJoined == null) {
+            studentsJoined = new ArrayList<>();
+        } else if (studentsJoined.contains(student)) {
+            throw new IllegalStateException("This student has already been accepted to join the course");
+        }
+
+        studentsRequesting.remove(student);
+        studentsJoined.add(student);
+    }
+
+    public void rejectStudent(User student) {
+        if (studentsRequesting == null || !studentsRequesting.contains(student)) {
+            throw new IllegalStateException("This student has no pending request to join this course");
+        }
+
+        if (studentsJoined == null) {
+            studentsJoined = new ArrayList<>();
+        } else if (studentsJoined.contains(student)) {
+            throw new IllegalStateException("This student has already been accepted to join the course");
+        }
+
+        studentsRequesting.remove(student);
+    }
+
+    public void removeStudent(User student) {
+        if (studentsJoined == null || !studentsJoined.contains(student)) {
+            throw new IllegalStateException("This student hasn't joined the course");
+        }
+
+        studentsJoined.remove(student);
     }
 }

--- a/src/main/java/it/ettore/model/User.java
+++ b/src/main/java/it/ettore/model/User.java
@@ -37,6 +37,12 @@ public class User {
     @OneToMany(mappedBy = "professor", cascade = CascadeType.ALL)
     private List<Course> coursesTaught = new ArrayList<>();
 
+    @ManyToMany(mappedBy = "studentsRequesting", cascade = CascadeType.ALL)
+    private List<Course> coursesRequesting;
+
+    @ManyToMany(mappedBy = "studentsJoined", cascade = CascadeType.ALL)
+    private List<Course> coursesJoined;
+
     public User(String firstName, String lastName, String email, String psw, Role role) {
         this.firstName = firstName;
         this.lastName = lastName;
@@ -83,6 +89,10 @@ public class User {
     public void setPassword(String psw) {
         assertPassword(psw);
         this.pswHash = hashPsw(psw);
+    }
+
+    public String fullName() {
+        return firstName + " " + lastName;
     }
 
     @Override

--- a/src/main/java/it/ettore/utils/DbBootstrapper.java
+++ b/src/main/java/it/ettore/utils/DbBootstrapper.java
@@ -5,9 +5,11 @@ import it.ettore.model.UserRepository;
 import it.ettore.model.Course;
 import it.ettore.model.CourseRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
 import java.util.List;
 
 /**
@@ -23,15 +25,28 @@ public class DbBootstrapper {
 
     @PostConstruct
     public void bootstrap() {
-        repoUser.save(new User("A", "Student", "a.student@ettore.it", "a.student@ettore.it", User.Role.STUDENT));
+        User student1 = new User("Student", "One", "student.one@ettore.it", "student.one@ettore.it", User.Role.STUDENT);
+        User student2 = new User("Student", "Two", "student.two@ettore.it", "student.two@ettore.it", User.Role.STUDENT);
+        User student3 = new User("Student", "Three", "student.three@ettore.it", "student.three@ettore.it", User.Role.STUDENT);
+        User student4 = new User("Student", "Four", "student.four@ettore.it", "student.four@ettore.it", User.Role.STUDENT);
+
         User professor = new User("B", "Professor", "a.professor@ettore.it", "a.professor@ettore.it", User.Role.PROFESSOR);
-        // Add math and history course to the professor
-        repoCourse.saveAll(List.of(
-                        new Course("Maths", "Maths course", 2023, Course.Category.Maths, professor),
-                        new Course("History", "History course", 2023, Course.Category.History, professor),
-                        new Course("Art", "Art course", 2023, Course.Category.Art, professor)
-                )
+
+        List<Course> courses = List.of(
+                new Course("Maths", "Maths course", 2023, Course.Category.Maths, professor),
+                new Course("History", "History course", 2023, Course.Category.History, professor),
+                new Course("Art", "Art course", 2023, Course.Category.Art, professor)
         );
+
+        courses.get(0).setStudentsRequesting(List.of(student2));
+        courses.get(0).setStudentsJoined(List.of(student1, student3, student4));
+
+        courses.get(1).setStudentsRequesting(List.of(student1, student3));
+        courses.get(1).setStudentsJoined(List.of(student2, student4));
+
+        courses.get(2).setStudentsJoined(List.of(student1, student2, student3));
+
+        repoCourse.saveAll(courses);
     }
 
 }

--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -58,6 +58,18 @@ button.et-button-disabled{
     filter: grayscale(1);
 }
 
+button.et-button-good{
+    background-color: var(--color-green);
+    color: var(--color-secondary);
+    border-radius: 0.5rem;
+}
+
+button.et-button-bad{
+    background-color: var(--color-red);
+    color: var(--color-secondary);
+    border-radius: 0.5rem;
+}
+
 /* Custom Ettore */
 
 .et-bg-background{
@@ -137,8 +149,8 @@ button.et-button-disabled{
     justify-content: center;
     align-items: stretch;
     flex-direction: column;
-    margin-left: 15rem;
-    margin-right: 15rem;
+    margin: 0 auto;
+    width: 40%;
     gap: 1.5rem;
 }
 

--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -66,7 +66,7 @@ button.et-button-good{
 
 button.et-button-bad{
     background-color: var(--color-red);
-    color: var(--color-secondary);
+    color: var(--color-window);
     border-radius: 0.5rem;
 }
 

--- a/src/main/resources/templates/common/header.html
+++ b/src/main/resources/templates/common/header.html
@@ -1,6 +1,6 @@
 <!-- Logout and username -->
 <div class="et-user-actions">
-    <p id="full-name" th:text="${user.firstName}+' '+${user.lastName}">FirstName LastName</p>
+    <p id="full-name" th:text="${user.fullName()}">FirstName LastName</p>
     <a href="/logout">Logout</a>
 </div>
 <!-- Header -->

--- a/src/main/resources/templates/professor/courses/details.html
+++ b/src/main/resources/templates/professor/courses/details.html
@@ -28,17 +28,17 @@
     </div>
     <!-- Lessons and Quiz -->
     <div class="grid grid-cols-2 gap-4">
-        <a th:href="'/professor/courses/'+${course.getId()}+'/lessons'" class="et-flex-centered flex-col et-card px-5 py-10">
+        <a id="btn-goto-lessons" th:href="'/professor/courses/'+${course.getId()}+'/lessons'" class="et-flex-centered flex-col et-card px-5 py-10">
             <i class="fa fa-file-alt fa-2x"></i>
             <p class="text-xl">Lectures</p>
         </a>
-        <a th:href="'/professor/courses/'+${course.getId()}+'/quizzes'" class="et-flex-centered flex-col et-card px-5 py-10">
+        <a id="btn-goto-quizzes" th:href="'/professor/courses/'+${course.getId()}+'/quizzes'" class="et-flex-centered flex-col et-card px-5 py-10">
             <i class="fa fa-clipboard-check fa-2x"></i>
             <p class="text-xl">Quizzes</p>
         </a>
     </div>
     <!-- Students -->
-    <a th:href="'/professor/courses/'+${course.getId()}+'/students'" class="et-flex-centered flex-col et-card px-5 py-10">
+    <a id="btn-goto-manage" th:href="'/professor/courses/'+${course.getId()}+'/manage'" class="et-flex-centered flex-col et-card px-5 py-10">
         <i class="fa fa-users fa-2x"></i>
         <p class="text-xl">Students</p>
     </a>

--- a/src/main/resources/templates/professor/courses/manage.html
+++ b/src/main/resources/templates/professor/courses/manage.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title th:text="'Edit - ' + ${course.getName()}"></title>
+    <meta th:replace="common/meta"/>
+</head>
+<body>
+<!-- Header with logo, logout and breadcrumbs -->
+<div th:replace="common/header"></div>
+<!-- Content -->
+<div class="et-content gap-4">
+    <!-- Incoming join requests -->
+    <div class="et-card p-5" id="list-students-requesting">
+        <h2 class="text-xl text-center mb-6 font-bold uppercase">Join Requests</h2>
+        <div class="flex flex-row items-center mb-2" th:each="student: ${studentsRequesting}">
+            <span class="text-xl" th:text="${student.fullName()}">Student</span>
+            <div class="flex-1"></div>
+            <button class="et-button-good h-9 px-2 mr-2" th:onclick="'document.location = \'/professor/courses/' + ${course.getId()} + '/accept/' + ${student.getId()} + '\''">Accept</button>
+            <button class="et-button-bad h-9 px-2" th:onclick="'document.location = \'/professor/courses/' + ${course.getId()} + '/reject/' + ${student.getId()} + '\''">Reject</button>
+        </div>
+    </div>
+    <!-- Students already joined -->
+    <div class="et-card p-5" id="list-students-joined">
+        <h2 class="text-xl text-center mb-6 font-bold uppercase">Students</h2>
+        <div class="flex flex-row items-center mb-2" th:each="student: ${studentsJoined}">
+            <span class="text-xl" th:text="${student.fullName()}">Student</span>
+            <div class="flex-1"></div>
+            <button class="et-button-bad h-9 px-2" th:onclick="'document.location = \'/professor/courses/' + ${course.getId()} + '/remove/' + ${student.getId()} + '\''">Remove</button>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/test/java/it/ettore/e2e/Authentication.java
+++ b/src/test/java/it/ettore/e2e/Authentication.java
@@ -13,20 +13,8 @@ public class Authentication extends E2EBaseTest {
     @Autowired
     protected UserRepository repoUser;
 
-    void clearDb() {
-        repoUser.deleteAll();
-    }
-
-    void ensureLoggedOut() {
-        clearDb();
-        // Make sure we're logged out
-        driver.get(baseDomain() + "logout");
-    }
-
     @Test
     public void canGoToLogin() {
-        ensureLoggedOut();
-
         // Can go freely to login page, even when unauthenticated
         driver.get(baseDomain() + "login");
         assertEquals("/login", currentPath());
@@ -34,8 +22,6 @@ public class Authentication extends E2EBaseTest {
 
     @Test
     public void canGoToRegister() {
-        ensureLoggedOut();
-
         // Can go freely to register page, even when unauthenticated
         driver.get(baseDomain() + "register");
         assertEquals("/register", currentPath());
@@ -43,8 +29,6 @@ public class Authentication extends E2EBaseTest {
 
     @Test
     public void cannotGoToSecurePages() {
-        ensureLoggedOut();
-
         // Check that we get redirected to login page
         driver.get(baseDomain() + "any-url-doesnt-matter");
         assertEquals("/login", currentPath());
@@ -52,8 +36,7 @@ public class Authentication extends E2EBaseTest {
 
     @Test
     public void canGoToCoursesList() {
-        ensureLoggedOut();
-        String email = "a.professor@ettore.it";
+        String email = "some.professor@ettore.it";
         String password = "SomeSecurePassword";
         repoUser.save(new User("FirstName", "LastName", email, password, User.Role.PROFESSOR));
 

--- a/src/test/java/it/ettore/e2e/E2EBaseTest.java
+++ b/src/test/java/it/ettore/e2e/E2EBaseTest.java
@@ -1,14 +1,19 @@
 package it.ettore.e2e;
 
 import io.github.bonigarcia.wdm.WebDriverManager;
+import it.ettore.model.CourseRepository;
+import it.ettore.model.LessonRepository;
+import it.ettore.model.UserRepository;
 import lombok.SneakyThrows;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.WebDriver;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.net.MalformedURLException;
@@ -16,6 +21,7 @@ import java.net.URL;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 // Every class that provides end-to-end test should extend from E2EBaseTest. This class handles the compilation and
 // deployment of the application on a random port and the setup of a browser driver.
 public abstract class E2EBaseTest {

--- a/src/test/java/it/ettore/e2e/Login.java
+++ b/src/test/java/it/ettore/e2e/Login.java
@@ -16,13 +16,8 @@ public class Login extends E2EBaseTest {
     @Autowired
     protected UserRepository repoUser;
 
-    void clearDb() {
-        repoUser.deleteAll();
-    }
-
     @Test
     public void login() {
-        clearDb();
         String email = "some.user@ettore.it";
         String password = "SomeSecurePassword";
         repoUser.save(new User("First", "Last", email, password, User.Role.PROFESSOR));
@@ -43,8 +38,6 @@ public class Login extends E2EBaseTest {
 
     @Test
     public void noSuchUser() {
-        clearDb();
-
         driver.get(baseDomain() + "login");
         // Check that we are on the right page
         assertEquals("I'm supposed to be in /login", "/login", currentPath());
@@ -62,7 +55,6 @@ public class Login extends E2EBaseTest {
 
     @Test
     public void wrongPassword() {
-        clearDb();
         String email = "some.user@ettore.it";
         String password = "SomeSecurePassword";
         repoUser.save(new User("First", "Last", email, password, User.Role.PROFESSOR));

--- a/src/test/java/it/ettore/e2e/Register.java
+++ b/src/test/java/it/ettore/e2e/Register.java
@@ -11,17 +11,8 @@ import java.util.Optional;
 import static org.junit.Assert.*;
 
 public class Register extends E2EBaseTest {
-    @Autowired
-    protected UserRepository repoUser;
-
-    void clearDb() {
-        repoUser.deleteAll();
-    }
-
     @Test
     public void allFieldsMustBeFilled() {
-        clearDb();
-
         driver.get(baseDomain() + "register");
         assertEquals("I'm supposed to be in /register", "/register", currentPath());
         RegisterPage registerPage = new RegisterPage(driver);
@@ -58,8 +49,6 @@ public class Register extends E2EBaseTest {
 
     @Test
     public void emailMustBeValid() {
-        clearDb();
-
         driver.get(baseDomain() + "register");
         assertEquals("I'm supposed to be in /register", "/register", currentPath());
         RegisterPage registerPage = new RegisterPage(driver);
@@ -95,8 +84,6 @@ public class Register extends E2EBaseTest {
 
     @Test
     public void passwordMustBeLongEnough() {
-        clearDb();
-
         driver.get(baseDomain() + "register");
         assertEquals("I'm supposed to be in /register", "/register", currentPath());
         RegisterPage registerPage = new RegisterPage(driver);
@@ -130,8 +117,6 @@ public class Register extends E2EBaseTest {
 
     @Test
     public void passwordsMustMatch() {
-        clearDb();
-
         driver.get(baseDomain() + "register");
         assertEquals("I'm supposed to be in /register", "/register", currentPath());
         RegisterPage registerPage = new RegisterPage(driver);
@@ -164,8 +149,6 @@ public class Register extends E2EBaseTest {
 
     @Test
     public void cannotRegisterSameEmailTwice() {
-        clearDb();
-
         driver.get(baseDomain() + "register");
         assertEquals("I'm supposed to be in /register", "/register", currentPath());
         RegisterPage registerPage = new RegisterPage(driver);

--- a/src/test/java/it/ettore/e2e/po/professor/ProfessorCoursePage.java
+++ b/src/test/java/it/ettore/e2e/po/professor/ProfessorCoursePage.java
@@ -27,6 +27,9 @@ public class ProfessorCoursePage extends PageObject {
     @FindBy(id = "btn-edit")
     private WebElement editButton;
 
+    @FindBy(id = "btn-goto-manage")
+    private WebElement gotoManageButton;
+
     public String getName() {
         return name.getText();
     }
@@ -37,6 +40,11 @@ public class ProfessorCoursePage extends PageObject {
 
     public String getDescription() {
         return description.getText();
+    }
+
+    public ProfessorManagePage gotoManage() {
+        gotoManageButton.click();
+        return new ProfessorManagePage(driver);
     }
 }
 

--- a/src/test/java/it/ettore/e2e/po/professor/ProfessorManagePage.java
+++ b/src/test/java/it/ettore/e2e/po/professor/ProfessorManagePage.java
@@ -1,0 +1,84 @@
+package it.ettore.e2e.po.professor;
+
+import it.ettore.e2e.po.Header;
+import it.ettore.e2e.po.LoginPage;
+import it.ettore.e2e.po.PageObject;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ProfessorManagePage extends PageObject {
+    public ProfessorManagePage(WebDriver driver) {
+        super(driver);
+    }
+
+    public Header headerComponent() {
+        return new Header(driver);
+    }
+
+    @EqualsAndHashCode
+    public static class StudentRequestingComponent {
+        private WebDriver driver;
+        private WebElement element;
+
+        public StudentRequestingComponent(WebDriver driver, WebElement element) {
+            this.driver = driver;
+            this.element = element;
+        }
+
+        public String getFullName() {
+            return element.findElement(By.tagName("span")).getText();
+        }
+
+        public ProfessorManagePage approve() {
+            element.findElement(By.xpath("//button[1]")).click();
+            return new ProfessorManagePage(driver);
+        }
+
+        public ProfessorManagePage reject() {
+            element.findElement(By.xpath("//button[2]")).click();
+            return new ProfessorManagePage(driver);
+        }
+    }
+
+    @EqualsAndHashCode
+    public static class StudentJoinedComponent {
+        private WebDriver driver;
+        private WebElement element;
+
+        public StudentJoinedComponent(WebDriver driver, WebElement element) {
+            this.driver = driver;
+            this.element = element;
+        }
+
+        public String getFullName() {
+            return element.findElement(By.tagName("span")).getText();
+        }
+
+        public ProfessorManagePage remove() {
+            element.findElement(By.xpath("//button")).click();
+            return new ProfessorManagePage(driver);
+        }
+    }
+
+    @FindBy(css = "#list-students-requesting > div")
+    private List<WebElement> studentsRequesting;
+
+    @FindBy(css = "#list-students-joined > div")
+    private List<WebElement> studentsJoined;
+
+    public List<StudentRequestingComponent> getStudentsRequesting() {
+        return studentsRequesting.stream().map(element -> new StudentRequestingComponent(driver, element)).collect(Collectors.toList());
+    }
+
+    public List<StudentJoinedComponent> getStudentsJoined() {
+        return studentsJoined.stream().map(element -> new StudentJoinedComponent(driver, element)).collect(Collectors.toList());
+    }
+}

--- a/src/test/java/it/ettore/e2e/professor/ProfessorCourse.java
+++ b/src/test/java/it/ettore/e2e/professor/ProfessorCourse.java
@@ -14,18 +14,10 @@ import static org.junit.Assert.assertEquals;
 
 public class ProfessorCourse extends E2EBaseTest {
     @Autowired
-    protected UserRepository repoUser;
-    @Autowired
     protected CourseRepository repoCourse;
-
-    void clearDb() {
-        repoCourse.deleteAll();
-        repoUser.deleteAll();
-    }
 
     @Test
     public void course() {
-        clearDb();
         String email = "some.professor@ettore.it";
         String password = "SomeSecurePassword";
         User professor = new User("Some", "Professor", email, password, User.Role.PROFESSOR);

--- a/src/test/java/it/ettore/e2e/professor/ProfessorCourses.java
+++ b/src/test/java/it/ettore/e2e/professor/ProfessorCourses.java
@@ -22,14 +22,8 @@ public class ProfessorCourses extends E2EBaseTest {
     @Autowired
     protected CourseRepository repoCourse;
 
-    void clearDb() {
-        repoCourse.deleteAll();
-        repoUser.deleteAll();
-    }
-
     @Test
     public void breadcrumbs() {
-        clearDb();
         String email = "some.professor@ettore.it";
         String password = "SomeSecurePassword";
         repoUser.save(new User("Some", "Professor", email, password, User.Role.PROFESSOR));
@@ -48,7 +42,6 @@ public class ProfessorCourses extends E2EBaseTest {
 
     @Test
     public void courses() {
-        clearDb();
         String email = "some.professor@ettore.it";
         String password = "SomeSecurePassword";
         User professor = new User("Some", "Professor", email, password, User.Role.PROFESSOR);

--- a/src/test/java/it/ettore/e2e/professor/ProfessorManage.java
+++ b/src/test/java/it/ettore/e2e/professor/ProfessorManage.java
@@ -1,0 +1,160 @@
+package it.ettore.e2e.professor;
+
+import it.ettore.e2e.E2EBaseTest;
+import it.ettore.e2e.po.LoginPage;
+import it.ettore.e2e.po.professor.ProfessorCoursePage;
+import it.ettore.e2e.po.professor.ProfessorCoursesPage;
+import it.ettore.e2e.po.professor.ProfessorCoursesPage.CourseComponent;
+import it.ettore.e2e.po.professor.ProfessorManagePage;
+import it.ettore.model.Course;
+import it.ettore.model.CourseRepository;
+import it.ettore.model.User;
+import it.ettore.model.UserRepository;
+import it.ettore.unit.CourseModel;
+import it.ettore.unit.UserModel;
+import it.ettore.utils.Breadcrumb;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class ProfessorManage extends E2EBaseTest {
+    @Autowired
+    protected CourseRepository repoCourse;
+
+    @Test
+    public void approveJoinRequest() {
+        String email = "some.professor@ettore.it";
+        String password = "SomeSecurePassword";
+        User professor = new User("Some", "Professor", email, password, User.Role.PROFESSOR);
+
+        Course course = new Course("Course name", "Course description", 2023, Course.Category.Maths, professor);
+
+        User student = new User("Some", "Student", "some.student@ettore.it", "ChocolatePizza", User.Role.STUDENT);
+        course.requestJoin(student);
+
+        repoCourse.save(course);
+
+        // Login with the professor's account
+        driver.get(baseDomain() + "login");
+        LoginPage loginPage = new LoginPage(driver);
+
+        loginPage.setEmail(email);
+        loginPage.setPassword(password);
+
+        ProfessorCoursesPage coursesPage = loginPage.loginAsProfessor();
+        ProfessorCoursePage coursePage = coursesPage.getCourses().get(0).goTo();
+        ProfessorManagePage managePage = coursePage.gotoManage();
+
+        // Should be in the manage page for the course
+        assertEquals(String.format("/professor/courses/%d/manage", course.getId()), currentPath());
+
+        // Should have one student asking to join
+        assertEquals(1, managePage.getStudentsRequesting().size());
+        assertEquals("Some Student", managePage.getStudentsRequesting().get(0).getFullName());
+        // Should have no students already in the course
+        assertEquals(0, managePage.getStudentsJoined().size());
+
+        // Approve join request
+        managePage = managePage.getStudentsRequesting().get(0).approve();
+
+        // Should still be in the manage page for the course
+        assertEquals(String.format("/professor/courses/%d/manage", course.getId()), currentPath());
+
+        // Should now have one student subscribed and none waiting to subscribe
+        assertEquals(0, managePage.getStudentsRequesting().size());
+        assertEquals(1, managePage.getStudentsJoined().size());
+        assertEquals("Some Student", managePage.getStudentsJoined().get(0).getFullName());
+    }
+
+    @Test
+    public void rejectJoinRequest() {
+        String email = "some.professor@ettore.it";
+        String password = "SomeSecurePassword";
+        User professor = new User("Some", "Professor", email, password, User.Role.PROFESSOR);
+
+        Course course = new Course("Course name", "Course description", 2023, Course.Category.Maths, professor);
+
+        User student = new User("Some", "Student", "some.student@ettore.it", "ChocolatePizza", User.Role.STUDENT);
+        course.requestJoin(student);
+
+        repoCourse.save(course);
+
+        // Login with the professor's account
+        driver.get(baseDomain() + "login");
+        LoginPage loginPage = new LoginPage(driver);
+
+        loginPage.setEmail(email);
+        loginPage.setPassword(password);
+
+        ProfessorCoursesPage coursesPage = loginPage.loginAsProfessor();
+        ProfessorCoursePage coursePage = coursesPage.getCourses().get(0).goTo();
+        ProfessorManagePage managePage = coursePage.gotoManage();
+
+        // Should be in the manage page for the course
+        assertEquals(String.format("/professor/courses/%d/manage", course.getId()), currentPath());
+
+        // Should have one student asking to join
+        assertEquals(1, managePage.getStudentsRequesting().size());
+        assertEquals("Some Student", managePage.getStudentsRequesting().get(0).getFullName());
+        // Should have no students already in the course
+        assertEquals(0, managePage.getStudentsJoined().size());
+
+        // Reject join request
+        managePage = managePage.getStudentsRequesting().get(0).reject();
+
+        // Should still be in the manage page for the course
+        assertEquals(String.format("/professor/courses/%d/manage", course.getId()), currentPath());
+
+        // Should now have no student subscribed and none waiting to subscribe
+        assertEquals(0, managePage.getStudentsRequesting().size());
+        assertEquals(0, managePage.getStudentsJoined().size());
+    }
+
+    @Test
+    public void removeStudent() {
+        String email = "some.professor@ettore.it";
+        String password = "SomeSecurePassword";
+        User professor = new User("Some", "Professor", email, password, User.Role.PROFESSOR);
+
+        Course course = new Course("Course name", "Course description", 2023, Course.Category.Maths, professor);
+
+        User student = new User("Some", "Student", "some.student@ettore.it", "ChocolatePizza", User.Role.STUDENT);
+        course.requestJoin(student);
+        // Immediately accept join request so we can remove him
+        course.acceptStudent(student);
+
+        repoCourse.save(course);
+
+        // Login with the professor's account
+        driver.get(baseDomain() + "login");
+        LoginPage loginPage = new LoginPage(driver);
+
+        loginPage.setEmail(email);
+        loginPage.setPassword(password);
+
+        ProfessorCoursesPage coursesPage = loginPage.loginAsProfessor();
+        ProfessorCoursePage coursePage = coursesPage.getCourses().get(0).goTo();
+        ProfessorManagePage managePage = coursePage.gotoManage();
+
+        // Should be in the manage page for the course
+        assertEquals(String.format("/professor/courses/%d/manage", course.getId()), currentPath());
+
+        // Should have one student already subscribed and none waiting to join
+        assertEquals(0, managePage.getStudentsRequesting().size());
+        assertEquals(1, managePage.getStudentsJoined().size());
+        assertEquals("Some Student", managePage.getStudentsJoined().get(0).getFullName());
+
+        // Reject join request
+        managePage = managePage.getStudentsJoined().get(0).remove();
+
+        // Should still be in the manage page for the course
+        assertEquals(String.format("/professor/courses/%d/manage", course.getId()), currentPath());
+
+        // Should now have no student subscribed and none waiting to subscribe
+        assertEquals(0, managePage.getStudentsRequesting().size());
+        assertEquals(0, managePage.getStudentsJoined().size());
+    }
+}

--- a/src/test/java/it/ettore/unit/UserModel.java
+++ b/src/test/java/it/ettore/unit/UserModel.java
@@ -6,6 +6,9 @@ import it.ettore.model.User;
 import org.junit.Test;
 
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.junit.Assert.*;
 
 public class UserModel {
@@ -88,5 +91,161 @@ public class UserModel {
         // Test that no exception is raised when adding a course to the ones taught by a professor
         professor.getCoursesTaught().add(new Course("Computer Architecture", "Bits are bits", 2023, Course.Category.Science, professor));
         professor.getCoursesTaught().remove(0);
+    }
+
+    @Test
+    public void requestCourseJoin() {
+        User professor = dummyProfessor();
+        Course course = CourseModel.dummyCourse(professor);
+
+        User student = dummyStudent();
+        course.requestJoin(student);
+
+        // Check that the list of students that want to join the course is exactly a 1-length list containing our dummy
+        // student
+        assertEquals(List.of(student), course.getStudentsRequesting());
+    }
+
+    @Test
+    public void approveCourseJoin() {
+        User professor = dummyProfessor();
+        Course course = CourseModel.dummyCourse(professor);
+
+        User student = dummyStudent();
+        // We need to use this trickery because List.of return an immutable List
+        course.setStudentsRequesting(new ArrayList<>(List.of(student)));
+
+        course.acceptStudent(student);
+
+        // There should be no pending join requests anymore, and one student that has joined
+        assertEquals(0, course.getStudentsRequesting().size());
+        assertEquals(List.of(student), course.getStudentsJoined());
+    }
+
+    @Test
+    public void rejectCourseJoin() {
+        User professor = dummyProfessor();
+        Course course = CourseModel.dummyCourse(professor);
+
+        User student = dummyStudent();
+        // We need to use this trickery because List.of return an immutable List
+        course.setStudentsRequesting(new ArrayList<>(List.of(student)));
+
+        course.rejectStudent(student);
+
+        // There should be no pending join requests anymore, and no students that have joined
+        assertEquals(0, course.getStudentsRequesting().size());
+        assertEquals(0, course.getStudentsJoined().size());
+    }
+
+    @Test
+    public void removeStudentFromCourse() {
+        User professor = dummyProfessor();
+        Course course = CourseModel.dummyCourse(professor);
+
+        User student = dummyStudent();
+        // We need to use this trickery because List.of return an immutable List
+        course.setStudentsJoined(new ArrayList<>(List.of(student)));
+
+        course.removeStudent(student);
+
+        // There should be no students that have joined
+        assertEquals(0, course.getStudentsJoined().size());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void requestCourseJoinButAlreadyDid() {
+        User professor = dummyProfessor();
+        Course course = CourseModel.dummyCourse(professor);
+
+        User student = dummyStudent();
+        // Say the student has already requested to join
+        // We need to use this trickery because List.of return an immutable List
+        course.setStudentsRequesting(new ArrayList<>(List.of(student)));
+
+        course.requestJoin(student);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void requestCourseJoinButAlreadyIn() {
+        User professor = dummyProfessor();
+        Course course = CourseModel.dummyCourse(professor);
+
+        User student = dummyStudent();
+        // Say the student has already joined
+        // We need to use this trickery because List.of return an immutable List
+        course.setStudentsJoined(new ArrayList<>(List.of(student)));
+
+        course.requestJoin(student);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void approveCourseJoinButDidntAsk() {
+        User professor = dummyProfessor();
+        Course course = CourseModel.dummyCourse(professor);
+
+        User student = dummyStudent();
+
+        course.acceptStudent(student);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void rejectCourseJoinButDidntAsk() {
+        User professor = dummyProfessor();
+        Course course = CourseModel.dummyCourse(professor);
+
+        User student = dummyStudent();
+
+        course.rejectStudent(student);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void approveCourseJoinButAlreadyIn() {
+        User professor = dummyProfessor();
+        Course course = CourseModel.dummyCourse(professor);
+
+        User student = dummyStudent();
+        // Say the student is already in
+        // We need to use this trickery because List.of return an immutable List
+        course.setStudentsJoined(new ArrayList<>(List.of(student)));
+
+        course.acceptStudent(student);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void rejectCourseJoinButAlreadyIn() {
+        User professor = dummyProfessor();
+        Course course = CourseModel.dummyCourse(professor);
+
+        User student = dummyStudent();
+        // Say the student is already in
+        // We need to use this trickery because List.of return an immutable List
+        course.setStudentsJoined(new ArrayList<>(List.of(student)));
+
+        course.rejectStudent(student);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void removeStudentFromCourseButNotApprovedYet() {
+        User professor = dummyProfessor();
+        Course course = CourseModel.dummyCourse(professor);
+
+        User student = dummyStudent();
+        // Say the student has requested to join but hasn't been approved yet
+        // We need to use this trickery because List.of return an immutable List
+        course.setStudentsRequesting(new ArrayList<>(List.of(student)));
+
+        course.removeStudent(student);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void removeStudentFromCourseButNotIn() {
+        User professor = dummyProfessor();
+        Course course = CourseModel.dummyCourse(professor);
+
+        User student = dummyStudent();
+        // Say the student is not in the course and hasn't requested to join
+
+        course.removeStudent(student);
     }
 }


### PR DESCRIPTION
- Added many-to-many relationships between `Course` and `Students` for those that want to join and those that already have
- Unit tests to check approval/rejection/removing process of students to/from a course
- Page at `/professor/id/courses/id/manage` for the professor to manage the students in his/her courses and those that want to join
- Added E2E tests for the above, along with page objects
- Removed `clearDb` paradigm from all E2E tests. The application context is now automatically reset after each test case
- Sprinkled some `id` in various pages to make page objects targeting of web elements easier
- Changed `.et-content` CSS class to take up less horizontal space and better match the Figma design

![image](https://user-images.githubusercontent.com/6002855/212408891-ddf2f4c0-3edc-47f2-8202-fde4a37f8e26.png)
