### PR TITLE
Errors system

### DIFF
--- a/src/main/java/it/ettore/controller/AuthController.java
+++ b/src/main/java/it/ettore/controller/AuthController.java
@@ -35,7 +35,7 @@ public class AuthController {
     ) {
         Optional<User> maybeUser = repoUser.findByEmail(email);
         if (maybeUser.isEmpty() || !maybeUser.get().getPswHash().equals(User.hashPsw(password))) { //maybe move hashPsw to Utils?
-            model.addAttribute("error", "Invalid credentials");
+            Utils.addError(model, "Invalid credentials");
             return "login";
         }
         User user = maybeUser.get();
@@ -71,7 +71,7 @@ public class AuthController {
                 role = User.Role.PROFESSOR;
                 break;
             default:
-                model.addAttribute("error", "Invalid role");
+                Utils.addError(model, "Invalid role");
                 return "register";
         }
 
@@ -79,7 +79,7 @@ public class AuthController {
         try {
             user = new User(firstName, lastName, email, password, role);
         } catch (IllegalArgumentException exc) {
-            model.addAttribute("error", exc.getMessage());
+            Utils.addError(model, exc.getMessage());
             return "register";
         }
 
@@ -87,7 +87,7 @@ public class AuthController {
             repoUser.save(user);
         } catch (Exception exc) {
             if (Utils.IsCause(exc, DataIntegrityViolationException.class)) {
-                model.addAttribute("error", "Email already taken");
+                Utils.addError(model, "Email already taken");
                 return "register";
             }
             // Unhandled exception

--- a/src/main/java/it/ettore/utils/Error.java
+++ b/src/main/java/it/ettore/utils/Error.java
@@ -1,0 +1,15 @@
+package it.ettore.utils;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class Error {
+    private final String message;
+
+    @Override
+    public String toString() {
+        return String.format("Error{%s}", message);
+    }
+}

--- a/src/main/java/it/ettore/utils/Utils.java
+++ b/src/main/java/it/ettore/utils/Utils.java
@@ -1,8 +1,10 @@
 package it.ettore.utils;
 
 import it.ettore.model.User;
+import org.springframework.ui.Model;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
 
 public class Utils {
     /**
@@ -29,5 +31,12 @@ public class Utils {
         Object userObj = request.getAttribute("user");
         if (!(userObj instanceof User)) throw new IllegalStateException("expected user");
         return (User) userObj;
+    }
+
+    public static void addError(Model model, String message) {
+        if (!model.containsAttribute("errors")) {
+            model.addAttribute("errors", new ArrayList<Error>());
+        }
+        ((ArrayList<Error>) model.getAttribute("errors")).add(new Error(message));
     }
 }

--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -9,7 +9,10 @@
         --color-text: #252525;
         --color-text-light: #C2C2C2;
         --color-green: #00EA6C;
+
+        --color-red-light: #ff9790;
         --color-red: #FF5C52;
+        --color-red-dark-translucent: rgba(222, 79, 71, 0.4);
     }
 }
 
@@ -164,4 +167,35 @@ button.et-button-bad{
 
 .et-already-registered > a {
     text-decoration: underline;
+}
+
+.et-errors {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+
+    display: flex;
+    flex-direction: column;
+
+    padding-right: 1rem;
+    padding-bottom: 1rem;
+    gap: 0.5rem;
+
+    width: 20rem;
+}
+
+.et-error {
+    box-sizing: border-box;
+    padding: 0.75rem;
+
+    color: var(--color-window);
+
+    background: var(--color-red);
+    border-radius: 0.5rem;
+    border: 1px solid var(--color-red-light);
+
+    box-shadow: var(--color-red-dark-translucent) 0px 8px 24px;
+
+    user-select: none;
+    cursor: pointer;
 }

--- a/src/main/resources/templates/common/errors.html
+++ b/src/main/resources/templates/common/errors.html
@@ -1,0 +1,8 @@
+<div class="et-errors">
+    <div class="et-error" title="Click to dismiss" th:each="error,iter: ${errors}" th:text="${error.getMessage()}" th:onclick="'dismissError('+${iter.index}+')'"></div>
+    <script>
+        function dismissError(idx) {
+            document.querySelector(".et-errors > .et-error:nth-child(" + (idx+1).toString() + ")").remove();
+        }
+    </script>
+</div>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -5,6 +5,7 @@
     <meta th:replace="common/meta"/>
 </head>
 <body class="et-flex-centered flex-col h-screen" onload="updateForm()">
+<div th:replace="common/errors"/>
 <div class="et-card et-flex-centered flex-col p-12">
     <h1 class="et-logo">ETTORE</h1>
     <form class="et-flex-centered flex-col mt-12" method="post" action="/login">
@@ -21,7 +22,6 @@
         <span style="display: none" class="text-red-700 self-start" id="password-too-short">Password is too short</span>
         <button class="et-button-primary et-button-disabled w-full h-12 mt-2" id="btn-login">Login</button>
     </form>
-    <div class="w-full mt-6 bg-red-400 p-2 rounded-md" id="error" th:if="${ error != null }" th:text="${ error }"></div>
     <hr class="w-2/3 my-8 bg-text-light"/>
     <button class="et-button-secondary w-full h-12" id="btn-goto-register" onclick="document.location = '/register'">Register
     </button>

--- a/src/main/resources/templates/professor/courses/details.html
+++ b/src/main/resources/templates/professor/courses/details.html
@@ -5,6 +5,7 @@
     <meta th:replace="common/meta"/>
 </head>
 <body>
+<div th:replace="common/errors"/>
 <!-- Header with logo, logout and breadcrumbs -->
 <div th:replace="common/header"></div>
 <!-- Content -->

--- a/src/main/resources/templates/professor/courses/list.html
+++ b/src/main/resources/templates/professor/courses/list.html
@@ -5,6 +5,7 @@
     <meta th:replace="common/meta"/>
 </head>
 <body>
+<div th:replace="common/errors"/>
 <!-- Header with logo, logout and breadcrumbs -->
 <div th:replace="common/header"></div>
 <!-- Content -->

--- a/src/main/resources/templates/professor/courses/manage.html
+++ b/src/main/resources/templates/professor/courses/manage.html
@@ -5,6 +5,7 @@
     <meta th:replace="common/meta"/>
 </head>
 <body>
+<div th:replace="common/errors"/>
 <!-- Header with logo, logout and breadcrumbs -->
 <div th:replace="common/header"></div>
 <!-- Content -->

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -5,6 +5,7 @@
     <meta th:replace="common/meta"/>
 </head>
 <body class="et-flex-centered flex-col h-screen" onload="updateForm()">
+<div th:replace="common/errors"/>
 <div class="et-card et-flex-centered flex-col p-12">
     <h1 class="et-logo">ETTORE</h1>
     <span class="et-subtitle">REGISTER</span>
@@ -51,7 +52,6 @@
         <span>Already a member?</span>
         <a href="/login" id="btn-goto-login">Go back to login</a>
     </div>
-    <div class="w-full mt-6 bg-red-400 p-2 rounded-md" id="error" th:if="${ error != null }" th:text="${ error }"></div>
 
     <script>
         // Don't show password error if password never been edited so far

--- a/src/test/java/it/ettore/e2e/Login.java
+++ b/src/test/java/it/ettore/e2e/Login.java
@@ -1,5 +1,6 @@
 package it.ettore.e2e;
 
+import it.ettore.e2e.po.ErrorsComponent;
 import it.ettore.e2e.po.professor.ProfessorCoursesPage;
 import it.ettore.e2e.po.LoginPage;
 import it.ettore.e2e.po.RegisterPage;
@@ -9,6 +10,7 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.Assert.*;
 
@@ -50,7 +52,12 @@ public class Login extends E2EBaseTest {
 
         // Check that we're still in /login
         assertEquals("I'm supposed to be in /login after a bad login", "/login", currentPath());
-        assertEquals(Optional.of("Invalid credentials"), loginPage.getError());
+        ErrorsComponent errors = new ErrorsComponent(driver);
+        assertEquals(Set.of("Invalid credentials"), errors.getErrorMessageSet());
+        // Dismiss the error
+        errors.getErrors().get(0).dismiss();
+        // Should now have no errors displayed
+        assertEquals(Set.of(), errors.getErrorMessageSet());
     }
 
     @Test
@@ -71,6 +78,11 @@ public class Login extends E2EBaseTest {
 
         // Check that we're still in /login
         assertEquals("I'm supposed to be in /login after a bad login", "/login", currentPath());
-        assertEquals(Optional.of("Invalid credentials"), loginPage.getError());
+        ErrorsComponent errors = new ErrorsComponent(driver);
+        assertEquals(Set.of("Invalid credentials"), errors.getErrorMessageSet());
+        // Dismiss the error
+        errors.getErrors().get(0).dismiss();
+        // Should now have no errors displayed
+        assertEquals(Set.of(), errors.getErrorMessageSet());
     }
 }

--- a/src/test/java/it/ettore/e2e/Register.java
+++ b/src/test/java/it/ettore/e2e/Register.java
@@ -1,5 +1,6 @@
 package it.ettore.e2e;
 
+import it.ettore.e2e.po.ErrorsComponent;
 import it.ettore.e2e.po.professor.ProfessorCoursesPage;
 import it.ettore.e2e.po.RegisterPage;
 import it.ettore.model.UserRepository;
@@ -7,6 +8,7 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.Assert.*;
 
@@ -181,6 +183,11 @@ public class Register extends E2EBaseTest {
         // Should be still in /register
         assertEquals("I'm supposed to be in /register", "/register", currentPath());
         // Assert error is shown
-        assertEquals(Optional.of("Email already taken"), registerPage.getError());
+        ErrorsComponent errors = new ErrorsComponent(driver);
+        assertEquals(Set.of("Email already taken"), errors.getErrorMessageSet());
+        // Dismiss the error
+        errors.getErrors().get(0).dismiss();
+        // Should now have no errors displayed
+        assertEquals(Set.of(), errors.getErrorMessageSet());
     }
 }

--- a/src/test/java/it/ettore/e2e/po/ErrorsComponent.java
+++ b/src/test/java/it/ettore/e2e/po/ErrorsComponent.java
@@ -1,0 +1,56 @@
+package it.ettore.e2e.po;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ErrorsComponent extends PageObject {
+    public ErrorsComponent(WebDriver driver) {
+        super(driver);
+    }
+
+    @FindBy(css = ".et-errors > .et-error")
+    private List<WebElement> errors;
+
+    public static class ErrorComponent {
+        // We need a reference to the parent, so we can call refresh() to refresh the list of displayed errors after we
+        // dismiss one
+        private ErrorsComponent parent;
+        private WebElement element;
+
+        public ErrorComponent(ErrorsComponent parent, WebElement element) {
+            this.parent = parent;
+            this.element = element;
+        }
+
+        public String getMessage() {
+            return element.getText();
+        }
+
+        public void dismiss() {
+            element.click();
+            this.parent.refresh();
+        }
+    }
+
+    /**
+     * Fetches the list of error components currently being displayed in the page. Useful if you want to interact with
+     * them.
+     */
+    public List<ErrorComponent> getErrors() {
+        return errors.stream().map(element -> new ErrorComponent(this, element)).collect(Collectors.toList());
+    }
+
+    /**
+     * Fetches the list of error components currently being displayed in the page but then only returns the set of their
+     * messages. Useful if only care about the messages (not interested in interacting) and the order in which they are
+     * displayed doesn't matter.
+     */
+    public Set<String> getErrorMessageSet() {
+        return getErrors().stream().map(ErrorComponent::getMessage).collect(Collectors.toSet());
+    }
+}

--- a/src/test/java/it/ettore/e2e/po/LoginPage.java
+++ b/src/test/java/it/ettore/e2e/po/LoginPage.java
@@ -30,17 +30,6 @@ public class LoginPage extends PageObject{
     @FindBy(name = "btn-goto-register")
     private WebElement gotoRegisterButton;
 
-    @FindBy(id = "error")
-    private WebElement errorMsg;
-
-    public Optional<String> getError() {
-        if (errorMsg != null) {
-            return Optional.of(errorMsg.getText());
-        } else {
-            return Optional.empty();
-        }
-    }
-
     public void setEmail(String email) {
         this.email.clear();
         this.email.sendKeys(email);

--- a/src/test/java/it/ettore/e2e/po/PageObject.java
+++ b/src/test/java/it/ettore/e2e/po/PageObject.java
@@ -11,4 +11,7 @@ public class PageObject {
         PageFactory.initElements(driver,this);
     }
 
+    public void refresh() {
+        PageFactory.initElements(driver,this);
+    }
 }

--- a/src/test/java/it/ettore/e2e/po/RegisterPage.java
+++ b/src/test/java/it/ettore/e2e/po/RegisterPage.java
@@ -48,17 +48,6 @@ public class RegisterPage extends PageObject {
     @FindBy(id = "btn-goto-login")
     private WebElement gotoLoginButton;
 
-    @FindBy(id = "error")
-    private WebElement errorMsg;
-
-    public Optional<String> getError() {
-        if (errorMsg != null) {
-            return Optional.of(errorMsg.getText());
-        } else {
-            return Optional.empty();
-        }
-    }
-
     public boolean isInvalidEmailFormatVisible() {
         return !invalidEmailFormatMsg.getCssValue("display").equals("none");
     }


### PR DESCRIPTION
Added a universal errors system, so the backend can display messages on the frontend.

![image](https://user-images.githubusercontent.com/6002855/212465050-9ff1a852-43cb-4b9f-92e6-ee4377af3582.png)

The errors can be clicked to dismiss them.

For a template to be able to display errors, it must have `<div th:replace="common/errors"/>` somewhere in its source code. The position is not super-important but I recommend placing it just after `<body>`.

In a controller, an error can be scheduled to be displayed in the returned template simply by calling: `Utils.addError(model, "Error message goes here");`

In testing, you can retrieve the list of displayed messages by creating an `ErrorsComponent` page object. You can even interact with them:

```java
ErrorsComponent errors = new ErrorsComponent(driver);

// Check that there is one error shown
assertEquals(1, errors.getErrors().size());
// Dismiss the error
errors.getErrors().get(0).dismiss();
// Should now have no errors displayed now
assertEquals(0, errors.getErrors().size());
```

If you only care about what messages are being shown (which means the order is unimportant and you don't wish to interact with them) then `getErrorMessageSet()` might be better suited because it returns a `Set<String>`:

```java
assertEquals(Set.of("Email already taken"), errors.getErrorMessageSet());
```