### PR TITLE
Improved auth interceptor and fixed logout

### DIFF
--- a/src/main/java/it/ettore/AuthInterceptor.java
+++ b/src/main/java/it/ettore/AuthInterceptor.java
@@ -3,14 +3,13 @@ package it.ettore;
 import it.ettore.model.User;
 import it.ettore.model.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * An interceptor that allows all whitelisted requests to pass-through, while all other requests need to be
@@ -22,44 +21,83 @@ public class AuthInterceptor implements HandlerInterceptor {
     @Autowired
     private UserRepository repoUser;
 
-    @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
-        // These do not require any authentication
-        List<String> whitelist = List.of(
-                "/style.css",
-                "/register",
-                "/login",
-                "/logout"
-        );
-
-        // If requested URL is whitelisted, we don't need to make any authentication check
-        if (whitelist.contains(request.getServletPath())) {
-            return HandlerInterceptor.super.preHandle(request, response, handler);
-        }
-
-        // Else, get the email and the password hash from the session. If they are null (or not a string, which would be
-        // weird) then redirect the user to the login page
+    private Optional<User> getLoggedUser(HttpServletRequest request) {
         Object emailObj = request.getSession().getAttribute("ETTORE_EMAIL");
         Object pswHashObj = request.getSession().getAttribute("ETTORE_PSW_HASH");
 
         if (!(emailObj instanceof String) || !(pswHashObj instanceof String)) {
-            response.sendRedirect("/login");
-            return false;
+            return Optional.empty();
         }
 
         String email = (String) emailObj;
         String pswHash = (String) pswHashObj;
 
-        // Find the user with the matching email and check that the password hash is correct. Otherwise, go back to the
-        // login
+        // Find the user with the matching email and check that the password hash is correct
         Optional<User> user = repoUser.findByEmail(email);
         if (user.isEmpty() || !user.get().getPswHash().equals(pswHash)) {
-            response.sendRedirect("/login");
-            return false;
+            return Optional.empty();
         }
 
-        // Store the user in the request attributes so that the actual handler can access the logged-in user
-        request.setAttribute("user", user.get());
-        return HandlerInterceptor.super.preHandle(request, response, handler);
+        return user;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        Optional<User> user = getLoggedUser(request);
+
+        if (user.isEmpty()) {
+            // If user is not logged in but wants to go to any of the following URLs, then that's ok. If he/she is
+            // trying to go to any other page, redirect to /login
+            if (Set.of(
+                    "/style.css",
+                    "/register",
+                    "/login",
+                    "/logout"
+            ).contains(request.getServletPath())) {
+                return HandlerInterceptor.super.preHandle(request, response, handler);
+            } else {
+                response.sendRedirect("/login");
+                return false;
+            }
+        } else {
+            // Store the user in the request attributes so that the actual handler can access the logged-in user
+            request.setAttribute("user", user.get());
+
+            //  Going to /style.css or /logout is always ok
+            if (Set.of(
+                    "/style.css",
+                    "/logout"
+            ).contains(request.getServletPath())) {
+                return HandlerInterceptor.super.preHandle(request, response, handler);
+            }
+
+            // Make sure the user is making a request to its respective section. i.e.:
+            //   - /professor/* If the user is a professor
+            //   - /student/* If the user is a student
+            // If this is not the case, then redirect the user to its homepage. Note that this also forbids the user
+            // from going to /login and /register. (But it allows going to /logout and /style.css because we've allowed
+            // that before even reaching this line)
+            User.Role pathRole;
+            if (request.getServletPath().startsWith("/professor")) {
+                pathRole = User.Role.PROFESSOR;
+            } else if (request.getServletPath().startsWith("/student")) {
+                pathRole = User.Role.STUDENT;
+            } else {
+                // This is not equal to User.Role.PROFESSOR nor User.Role.STUDENT so it can never be equal to
+                // user.get().getRole() which means the user is redirected to its homepage. This happens i.e. when going
+                // to /login or /register when already authenticated
+                pathRole = null;
+            }
+
+            if (user.get().getRole() == pathRole) {
+                return HandlerInterceptor.super.preHandle(request, response, handler);
+            } else if (user.get().getRole() == User.Role.PROFESSOR) {
+                response.sendRedirect("/professor/courses");
+                return false;
+            } else {
+                response.sendRedirect("/student/courses");
+                return false;
+            }
+        }
     }
 }

--- a/src/main/java/it/ettore/controller/AuthController.java
+++ b/src/main/java/it/ettore/controller/AuthController.java
@@ -103,7 +103,8 @@ public class AuthController {
 
     @GetMapping("/logout")
     public String logout(HttpServletRequest request) {
-        request.getSession().removeAttribute("PSW_HASH");
+        request.getSession().removeAttribute("ETTORE_EMAIL");
+        request.getSession().removeAttribute("ETTORE_PSW_HASH");
         return "redirect:/login";
     }
 

--- a/src/test/java/it/ettore/e2e/Authentication.java
+++ b/src/test/java/it/ettore/e2e/Authentication.java
@@ -1,6 +1,7 @@
 package it.ettore.e2e;
 
 import it.ettore.e2e.po.LoginPage;
+import it.ettore.e2e.po.professor.courses.ProfessorCoursesPage;
 import it.ettore.model.User;
 import it.ettore.model.UserRepository;
 import org.junit.Test;
@@ -13,6 +14,9 @@ public class Authentication extends E2EBaseTest {
     @Autowired
     protected UserRepository repoUser;
 
+    /**
+     * When logged out, a user should be able to navigate to /login freely
+     */
     @Test
     public void canGoToLogin() {
         // Can go freely to login page, even when unauthenticated
@@ -20,6 +24,9 @@ public class Authentication extends E2EBaseTest {
         assertEquals("/login", currentPath());
     }
 
+    /**
+     * When logged out, a user should be able to navigate to /register freely
+     */
     @Test
     public void canGoToRegister() {
         // Can go freely to register page, even when unauthenticated
@@ -27,13 +34,23 @@ public class Authentication extends E2EBaseTest {
         assertEquals("/register", currentPath());
     }
 
+    /**
+     * When logged out, a user should not be able to navigate to any other page except from /login, /register (and
+     * also get /style.css). This also includes non-existing pages. He/She should be redirected to /login if that
+     * happens.
+     */
     @Test
     public void cannotGoToSecurePages() {
         // Check that we get redirected to login page
         driver.get(baseDomain() + "any-url-doesnt-matter");
         assertEquals("/login", currentPath());
+        driver.get(baseDomain() + "professor/courses");
+        assertEquals("/login", currentPath());
     }
 
+    /**
+     * Once logged in, a professor can go to its homepage
+     */
     @Test
     public void canGoToCoursesList() {
         String email = "some.professor@ettore.it";
@@ -49,5 +66,133 @@ public class Authentication extends E2EBaseTest {
 
         // Check that we get redirected to the courses list page
         assertEquals("/professor/courses", currentPath());
+    }
+
+    /**
+     * Once logged in, a user shouldn't be able to go to /login. He/She should be redirected to his/her homepage
+     * instead
+     */
+    @Test
+    public void onceLoggedInCannotLoginAgain() {
+        String email = "some.professor@ettore.it";
+        String password = "SomeSecurePassword";
+        repoUser.save(new User("FirstName", "LastName", email, password, User.Role.PROFESSOR));
+
+        // Login
+        driver.get(baseDomain() + "login");
+        LoginPage loginPage = new LoginPage(driver);
+        loginPage.setEmail(email);
+        loginPage.setPassword(password);
+        loginPage.loginAsProfessor();
+
+        // Check that we get redirected to the courses list page
+        assertEquals("/professor/courses", currentPath());
+
+        driver.get(baseDomain() + "login");
+
+        // Check that we get redirected to the courses list page instead of going to /login
+        assertEquals("/professor/courses", currentPath());
+    }
+
+    /**
+     * Once logged in, a user shouldn't be able to go to /register. He/She should be redirected to his/her homepage
+     * instead
+     */
+    @Test
+    public void onceLoggedInCannotRegisterAgain() {
+        String email = "some.professor@ettore.it";
+        String password = "SomeSecurePassword";
+        repoUser.save(new User("FirstName", "LastName", email, password, User.Role.PROFESSOR));
+
+        // Login
+        driver.get(baseDomain() + "login");
+        LoginPage loginPage = new LoginPage(driver);
+        loginPage.setEmail(email);
+        loginPage.setPassword(password);
+        loginPage.loginAsProfessor();
+
+        // Check that we get redirected to the courses list page
+        assertEquals("/professor/courses", currentPath());
+
+        driver.get(baseDomain() + "register");
+
+        // Check that we get redirected to the courses list page instead of going to /register
+        assertEquals("/professor/courses", currentPath());
+    }
+
+    /**
+     * A user should be able to logout. Which means being redirected to /login and not being able to see any another
+     * parts of Ettore
+     */
+    @Test
+    public void canLogout() {
+        String email = "some.professor@ettore.it";
+        String password = "SomeSecurePassword";
+        repoUser.save(new User("FirstName", "LastName", email, password, User.Role.PROFESSOR));
+
+        // Login
+        driver.get(baseDomain() + "login");
+        LoginPage loginPage = new LoginPage(driver);
+        loginPage.setEmail(email);
+        loginPage.setPassword(password);
+        ProfessorCoursesPage coursesPage = loginPage.loginAsProfessor();
+
+        // Check that we get redirected to the courses list page
+        assertEquals("/professor/courses", currentPath());
+
+        coursesPage.headerComponent().logout();
+
+        // Check that we're in /login
+        assertEquals("/login", currentPath());
+
+        // And cannot go to authenticated pages
+        driver.get(baseDomain() + "professor/courses");
+        assertEquals("/login", currentPath());
+    }
+
+    /**
+     * A professor should not be able to navigate or make requests to the student's side of Ettore
+     */
+    @Test
+    public void professorCannotGoToStudentSection() {
+        String email = "some.professor@ettore.it";
+        String password = "SomeSecurePassword";
+        repoUser.save(new User("FirstName", "LastName", email, password, User.Role.PROFESSOR));
+
+        // Login
+        driver.get(baseDomain() + "login");
+        LoginPage loginPage = new LoginPage(driver);
+        loginPage.setEmail(email);
+        loginPage.setPassword(password);
+        loginPage.loginAsProfessor();
+
+        // Try to go to the student's side
+        driver.get(baseDomain() + "student/courses");
+
+        // We should have been redirected to our homepage
+        assertEquals("/professor/courses", currentPath());
+    }
+
+    /**
+     * A student should not be able to navigate or make requests to the professor's side of Ettore
+     */
+    @Test
+    public void studentCannotGoToProfessorSection() {
+        String email = "some.student@ettore.it";
+        String password = "SomeSecurePassword";
+        repoUser.save(new User("FirstName", "LastName", email, password, User.Role.STUDENT));
+
+        // Login
+        driver.get(baseDomain() + "login");
+        LoginPage loginPage = new LoginPage(driver);
+        loginPage.setEmail(email);
+        loginPage.setPassword(password);
+        loginPage.loginAsProfessor();
+
+        // Try to go to the professor's side
+        driver.get(baseDomain() + "professor/courses");
+
+        // We should have been redirected to our homepage
+        assertEquals("/student/courses", currentPath());
     }
 }

--- a/src/test/java/it/ettore/e2e/Register.java
+++ b/src/test/java/it/ettore/e2e/Register.java
@@ -168,11 +168,11 @@ public class Register extends E2EBaseTest {
         registerPage.setConfirmPassword("alien_spy");
 
         registerPage.tickProfessor();
-        registerPage.registerAsProfessor();
+        ProfessorCoursesPage coursesPage = registerPage.registerAsProfessor();
         assertEquals("I'm supposed to be in /professor/courses", "/professor/courses", currentPath());
 
-        driver.get(baseDomain() + "register");
-        registerPage = new RegisterPage(driver);
+        LoginPage loginPage = coursesPage.headerComponent().logout();
+        registerPage = loginPage.register();
         assertEquals("I'm supposed to be in /register", "/register", currentPath());
 
         // Try to register again, use the same email

--- a/src/test/java/it/ettore/e2e/po/LoginPage.java
+++ b/src/test/java/it/ettore/e2e/po/LoginPage.java
@@ -27,7 +27,7 @@ public class LoginPage extends PageObject {
     @FindBy(id = "btn-login")
     private WebElement loginButton;
 
-    @FindBy(name = "btn-goto-register")
+    @FindBy(id = "btn-goto-register")
     private WebElement gotoRegisterButton;
 
     public void setEmail(String email) {

--- a/src/test/java/it/ettore/e2e/professor/courses/ProfessorCourse.java
+++ b/src/test/java/it/ettore/e2e/professor/courses/ProfessorCourse.java
@@ -38,7 +38,7 @@ public class ProfessorCourse extends E2EBaseTest {
         loginPage.setPassword(password);
         loginPage.loginAsProfessor();
 
-        driver.get(baseDomain() + String.format("/professor/courses/%d", course.getId()));
+        driver.get(baseDomain() + String.format("professor/courses/%d", course.getId()));
 
         ProfessorCoursePage coursePage = new ProfessorCoursePage(driver);
 


### PR DESCRIPTION
- A logged in user can no longer navigate to `/login` or `/logout`
- A logged in professor can no longer navigate or make requests to URLs beginning with `/student`
- A logged in student can no longer navigate or make requests to URLs beginning with `/professor`
- Fixed `/logout` handler removing the wrong session attributes
- Fixed a couple of E2E tests that either didn't work anymore because of the stricter `AuthInterceptor` plus a test that used the wrong `@FindBy`